### PR TITLE
Use getClientId instead of getName for getting clients' name

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authorization/client/access/policy/PolicyBasedAccessProvider.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/access/policy/PolicyBasedAccessProvider.java
@@ -46,7 +46,7 @@ public final class PolicyBasedAccessProvider implements AccessProvider {
 
         if (resource == null || resourceServer == null) {
             LOG.warnf("Possible configuration issue: Could not find resource '%s' for client '%s' in realm '%s'.",
-                RESOURCE_NAME, client.getName(), client.getRealm().getName());
+                RESOURCE_NAME, client.getClientId(), client.getRealm().getName());
             return false;
         }
 
@@ -62,7 +62,7 @@ public final class PolicyBasedAccessProvider implements AccessProvider {
             logAccessDenied(client, user);
             LOG.warnf(
                 "Possible configuration issue: Did you forget to add a permission or policy for client '%s' and resource '%s' in realm '%s'",
-                client.getName(), RESOURCE_NAME, client.getRealm().getName());
+                client.getClientId(), RESOURCE_NAME, client.getRealm().getName());
             return false;
         }
 

--- a/src/main/java/de/sventorben/keycloak/authorization/client/access/role/ClientRoleBasedAccessProvider.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/access/role/ClientRoleBasedAccessProvider.java
@@ -30,10 +30,10 @@ public final class ClientRoleBasedAccessProvider implements AccessProvider {
         if (permitted) {
             LOG.debugf(
                 "Access for user '%s' to client '%s' in realm '%s' granted.",
-                user.getUsername(), client.getName(), client.getRealm().getName());
+                user.getUsername(), client.getClientId(), client.getRealm().getName());
         } else {
             LOG.warnf("Access for user '%s' to client '%s' in realm '%s' is denied. User does not have client role '%s' on client with id '%s'.",
-                    user.getUsername(), client.getName(), client.getRealm().getName(), clientRoleName, client.getId());
+                    user.getUsername(), client.getClientId(), client.getRealm().getName(), clientRoleName, client.getId());
         }
         return permitted;
     }


### PR DESCRIPTION
Hi!

When looking at the logs messages:

> Jan 24 09:53:41 auth.bbp.epfl.ch keycloak[2359967]: 2023-01-24 09:53:41,858 WARN  [de.sventorben.keycloak.authorization.client.access.role.ClientRoleBasedAccessProvider] (executor-thread-8) Access for user 'danielfr' to client '' in realm 'BBP' is denied. User does not have client role 'restricted-access' on client with id 'b5c85eb7-9a94-4058-b483-a2e7f29f995e'.

The client name seems to be empty.

The current version of the authenticator uses `getName()` to get the clients' name, but this attribute is optional in Keycloak.
I'd suggest changing it by `getClientId()`  (https://github.com/keycloak/keycloak/blob/main/server-spi/src/main/java/org/keycloak/models/ClientModel.java#L112) that returns the mandatory "client ID" attribute as defined by the user.
