### PR TITLE
Update Keycloak dependencies to 22.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,8 +38,8 @@ body:
     label: Version
     description: |
       examples:
-        - **Keycloak**: 21.1.2
-        - **This extension**:  21.0.0
+        - **Keycloak**: 22.0.0
+        - **This extension**: 22.0.0
     value: |
         - Keycloak:
         - This extension:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keycloak_version: [ 21.0.2, 21.1.2, latest ]
+        keycloak_version: [ 22.0.0, latest ]
         keycloak_dist: [quarkus]
         experimental: [false]
         include:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a simple Keycloak authenticator to restrict user authorization on clients.
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/sventorben/keycloak-restrict-client-auth?sort=semver)
-![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-21.1.2-blue)
+![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-22.0.0-blue)
 ![GitHub Release Date](https://img.shields.io/github/release-date-pre/sventorben/keycloak-restrict-client-auth)
 ![Github Last Commit](https://img.shields.io/github/last-commit/sventorben/keycloak-restrict-client-auth)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   keycloak:
     container_name: keycloak
-    image: quay.io/keycloak/keycloak:21.1.2
+    image: quay.io/keycloak/keycloak:22.0.0
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.sventorben.keycloak</groupId>
     <artifactId>keycloak-restrict-client-auth</artifactId>
-    <version>21.0.1-SNAPSHOT</version>
+    <version>22.0.0-SNAPSHOT</version>
 
     <name>Keycloak: Authenticator - Restrict client authentication</name>
     <description>A Keycloak authenticator to restrict authentication on clients</description>
@@ -51,7 +51,7 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <!-- For compilation -->
-        <version.keycloak>21.1.2</version.keycloak>
+        <version.keycloak>22.0.0</version.keycloak>
 
         <!-- For compatibility tests -->
         <keycloak.version>${version.keycloak}</keycloak.version>
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>com.github.dasniko</groupId>
             <artifactId>testcontainers-keycloak</artifactId>
-            <version>2.3.0</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/de/sventorben/keycloak/authorization/client/RestrictClientAuthAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/RestrictClientAuthAuthenticator.java
@@ -2,6 +2,8 @@ package de.sventorben.keycloak.authorization.client;
 
 import de.sventorben.keycloak.authorization.client.access.AccessProvider;
 import de.sventorben.keycloak.authorization.client.access.role.ClientRoleBasedAccessProviderFactory;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
@@ -15,9 +17,6 @@ import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.utils.MediaTypeMatcher;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 final class RestrictClientAuthAuthenticator implements Authenticator {
 

--- a/src/test/java/de/sventorben/keycloak/authorization/client/ClientPolicyIT.java
+++ b/src/test/java/de/sventorben/keycloak/authorization/client/ClientPolicyIT.java
@@ -1,8 +1,8 @@
 package de.sventorben.keycloak.authorization.client;
 
 import dasniko.testcontainers.keycloak.KeycloakContainer;
+import jakarta.ws.rs.NotAuthorizedException;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -18,25 +18,12 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import javax.ws.rs.NotAuthorizedException;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.UUID;
 
-import static de.sventorben.keycloak.authorization.client.TestConstants.CLIENT_SECRET_TEST_RESTRICTED_BY_POLICY;
-import static de.sventorben.keycloak.authorization.client.TestConstants.CLIENT_TEST_RESTRICTED_BY_POLICY;
-import static de.sventorben.keycloak.authorization.client.TestConstants.CLIENT_TEST_UNRESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.KEYCLOAK_ADMIN_PASS;
-import static de.sventorben.keycloak.authorization.client.TestConstants.KEYCLOAK_ADMIN_USER;
-import static de.sventorben.keycloak.authorization.client.TestConstants.KEYCLOAK_HTTP_PORT;
-import static de.sventorben.keycloak.authorization.client.TestConstants.PASS_TEST_RESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.PASS_TEST_UNRESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.REALM_TEST;
-import static de.sventorben.keycloak.authorization.client.TestConstants.USER_TEST_RESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.USER_TEST_UNRESTRICTED;
+import static de.sventorben.keycloak.authorization.client.TestConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 @Testcontainers
 class ClientPolicyIT {

--- a/src/test/java/de/sventorben/keycloak/authorization/client/LoginIT.java
+++ b/src/test/java/de/sventorben/keycloak/authorization/client/LoginIT.java
@@ -1,6 +1,7 @@
 package de.sventorben.keycloak.authorization.client;
 
 import dasniko.testcontainers.keycloak.KeycloakContainer;
+import jakarta.ws.rs.NotAuthorizedException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -16,23 +17,12 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import javax.ws.rs.NotAuthorizedException;
 import java.time.Duration;
 import java.util.Map;
 
-import static de.sventorben.keycloak.authorization.client.TestConstants.CLIENT_SECRET_TEST_RESTRICTED_BY_POLICY;
-import static de.sventorben.keycloak.authorization.client.TestConstants.CLIENT_TEST_RESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.CLIENT_TEST_RESTRICTED_BY_POLICY;
-import static de.sventorben.keycloak.authorization.client.TestConstants.CLIENT_TEST_UNRESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.KEYCLOAK_HTTP_PORT;
-import static de.sventorben.keycloak.authorization.client.TestConstants.PASS_TEST_RESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.PASS_TEST_UNRESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.REALM_TEST;
-import static de.sventorben.keycloak.authorization.client.TestConstants.USER_TEST_RESTRICTED;
-import static de.sventorben.keycloak.authorization.client.TestConstants.USER_TEST_UNRESTRICTED;
+import static de.sventorben.keycloak.authorization.client.TestConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 @Testcontainers
 class LoginIT {
@@ -66,7 +56,7 @@ class LoginIT {
         @CsvSource(value = {"client-role", "null"}, nullValues = "null")
         void accessForUserWithoutRoleIsDenied(String accessProviderId) {
             LoginIT.this.switchAccessProvider(accessProviderId);
-            try(Keycloak keycloak = keycloakTest(USER_TEST_RESTRICTED, PASS_TEST_RESTRICTED, CLIENT_TEST_RESTRICTED)) {
+            try (Keycloak keycloak = keycloakTest(USER_TEST_RESTRICTED, PASS_TEST_RESTRICTED, CLIENT_TEST_RESTRICTED)) {
                 assertThatThrownBy(() -> keycloak.tokenManager().grantToken())
                     .isInstanceOf(NotAuthorizedException.class);
             }
@@ -101,7 +91,7 @@ class LoginIT {
 
         @Test
         void accessForUserWithRoleIsAllowed() {
-            try(Keycloak keycloak = keycloakTest(USER_TEST_UNRESTRICTED, PASS_TEST_UNRESTRICTED,
+            try (Keycloak keycloak = keycloakTest(USER_TEST_UNRESTRICTED, PASS_TEST_UNRESTRICTED,
                 CLIENT_TEST_RESTRICTED_BY_POLICY, CLIENT_SECRET_TEST_RESTRICTED_BY_POLICY)) {
                 assertThat(keycloak.tokenManager().grantToken()).isNotNull();
             }
@@ -118,14 +108,14 @@ class LoginIT {
 
         @Test
         void accessForRestrictedUserIsAllowed() {
-            try(Keycloak keycloak = keycloakTest(USER_TEST_RESTRICTED, PASS_TEST_RESTRICTED, CLIENT_TEST_UNRESTRICTED)) {
+            try (Keycloak keycloak = keycloakTest(USER_TEST_RESTRICTED, PASS_TEST_RESTRICTED, CLIENT_TEST_UNRESTRICTED)) {
                 assertThat(keycloak.tokenManager().grantToken()).isNotNull();
             }
         }
 
         @Test
         void accessForUnrestrictedUserIsAllowed() {
-            try(Keycloak keycloak = keycloakTest(USER_TEST_UNRESTRICTED, PASS_TEST_UNRESTRICTED, CLIENT_TEST_UNRESTRICTED)) {
+            try (Keycloak keycloak = keycloakTest(USER_TEST_UNRESTRICTED, PASS_TEST_UNRESTRICTED, CLIENT_TEST_UNRESTRICTED)) {
                 assertThat(keycloak.tokenManager().grantToken()).isNotNull();
             }
         }
@@ -133,7 +123,7 @@ class LoginIT {
 
 
     private void switchAccessProvider(String accessProviderId) {
-        try(Keycloak admin = keycloakAdmin()) {
+        try (Keycloak admin = keycloakAdmin()) {
             AuthenticationManagementResource flows = admin.realm(REALM_TEST).flows();
             String authenticationConfigId = flows
                 .getExecutions("direct-grant-restrict-client-auth").stream()


### PR DESCRIPTION
This includes breaking changes due to transition from Java EE to Jakarta EE. As part of upgrading to Quarkus 3.x Keycloak migrated its codebase from Java EE to the successor Jakarta EE. This updates reflects the changes.