### PR TITLE
Add a docker release

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,39 @@
+name: build and release docker image
+
+on:
+  workflow_run:
+    workflows: Release
+    types:
+    - completed
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: sventorben/keycloak-restrict-client-auth
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM maven:3.9.3-eclipse-temurin-17-focal
+COPY src /home/app/src
+COPY pom.xml /home/app
+RUN mvn -f /home/app/pom.xml -B clean package
+RUN mkdir -p /opt/keycloak/providers
+RUN mv /home/app/target/keycloak-restrict-client-auth.jar /opt/keycloak/providers


### PR DESCRIPTION
Adding a Docker release workflow for the keycloak-restrict-client-auth jar.

Addresses https://github.com/sventorben/keycloak-restrict-client-auth/issues/192