### PR TITLE
Docs: additional explanation for "protect all flows"

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ If you are using a Keycloak adapter, make sure your clients are verifying the au
 
 ### Protect all possible flows
 
-Ensure that you protect access to your clients in all flows, not just the browser flow. Failure to do so may allow malicious users to obtain access or identity tokens via other flows.
-Especially post login flows of identity providers and flows used in authentication flow overrides are often overlooked.
+Ensure that you protect authentication to your clients in all flows a user may access. This includes not just the browser flow or the other realm-wide flows, but also identity provider overrides and post login flows.
+
+Here is one example: suppose a user tries to log in via the built-in browser flow, at the end of which you have added the "Restrict user authentication on clients" step. If the "Cookie" or "Forms" alternative is used, the user will proceed to this step and be evaluated. But if it is the "Identity Provider Redirector" alternative which gets used, the subsequent steps will be skipped and the user will not be subject to this validation (this is a general feature of how brokering works in Keycloak authentication flows, not specific to this plugin). This extension must also be configured in the identity provider's post login flow in order to apply.
 
 ### Disable the `Audience Resolve` mapper if necessary
 The [`Audience Resolve` protocol mapper](https://www.keycloak.org/docs/latest/server_admin/#_audience_resolve) is enabled by default by client scope `roles`, but it may be necessary to remove it in some cases.


### PR DESCRIPTION
Mainly adds additional explanation of post login flows, which are not unique to this extension but highly relevant. This additional information would be helpful for new/prospective users like me. Keycloak's own documentation seems to lack a searchable explanation about how brokering bypasses subsequent authentication flow steps, and not only allows but really requires explicit post login flows.