### PR TITLE
docs: keycloak Authorization Services Guide url

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ It may happen that I remove older packages without prior notice, because the sto
 * Create a new flow per binding (e.g. browser flow, direct grant flow etc.)
 * Add a sub-flow e.g. named `Login` and mark it as `Required`
 * Add an authenticator execution `Restrict user authentication on clients` and mark the execution as `Required`.
-* Within the `Login` sub-flow add authenticators/executions/conditionals and further sub-flows as needed (see [Keycload documentation for details](https://www.keycloak.org/docs/21.0.1/server_admin/#_authentication-flows)
+* Within the `Login` sub-flow add authenticators/executions/conditionals and further sub-flows as needed (
+  see [Keycload documentation for details](https://www.keycloak.org/docs/latest/server_admin/#_authentication-flows)
 * Then bind your newly created flow as desired - either as a default for the whole realm or on a per-client basis.
 
   See the image below for an example.


### PR DESCRIPTION
link was broken so I updated it with a functional one