### PR TITLE
feat: filter account console applications based on access permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,51 @@ This extension provides a [client policy condition](https://www.keycloak.org/doc
 ### Executors
 This extension provides a [client policy executor](https://www.keycfloak.org/docs/latest/server_admin/#executor) named `restrict-client-auth-auto-config` to automatically enable restricted access for clients. The executor can be cofigured to either enable restricted access based on resource policies or based on client role.
 
+## Account Console filtering
+
+By default, users can see all applications in their Keycloak Account Console (`/realms/{realm}/account/applications`), including applications they are restricted from accessing.
+
+This extension provides optional filtering to hide restricted applications from users who do not have permission to access them.
+
+### How it works
+
+The filter intercepts the Account Console's applications endpoint and removes clients that:
+1. Have restricted access enabled (via role or policy)
+2. The current user does not have permission to access
+
+Unrestricted clients are always shown. Restricted clients are only shown to users who have the required role or policy permission.
+
+### Configuration
+
+Account Console filtering is controlled by two configuration properties:
+
+```properties
+# Filter applications that appear dynamically (based on user sessions/consents)
+# Default: true
+spi-restrict-client-auth-account-filter-default-filter-dynamic-apps=true
+
+# Filter applications marked as "Always display in console"
+# Default: true
+spi-restrict-client-auth-account-filter-default-filter-always-display-apps=true
+```
+
+Both options default to `true` (filtering enabled). You can disable either independently:
+
+```properties
+# Example: Only filter dynamic apps, but always show "Always display in console" apps
+spi-restrict-client-auth-account-filter-default-filter-dynamic-apps=true
+spi-restrict-client-auth-account-filter-default-filter-always-display-apps=false
+```
+
+### Behavior summary
+
+| Client State | User Has Permission | Filtering Enabled | Visible in Account Console |
+|--------------|---------------------|-------------------|----------------------------|
+| Not restricted | N/A | N/A | Yes |
+| Restricted | Yes | N/A | Yes |
+| Restricted | No | Yes | No |
+| Restricted | No | No (opt-out) | Yes |
+
 ## Security considerations
 
 ### Policy enforcement

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
             <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive</artifactId>
+            <version>3.19.4</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilter.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilter.java
@@ -1,0 +1,172 @@
+package de.sventorben.keycloak.authorization.client.account;
+
+import de.sventorben.keycloak.authorization.client.access.AccessProvider;
+import de.sventorben.keycloak.authorization.client.access.role.ClientRoleBasedAccessProviderFactory;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+import org.keycloak.common.util.Resteasy;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.account.ClientRepresentation;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.services.managers.AuthenticationManager;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Provider
+public class AccountApplicationsFilter {
+
+    private static final Logger LOG = Logger.getLogger(AccountApplicationsFilter.class);
+
+    @ServerResponseFilter
+    @SuppressWarnings({"deprecation", "unused"}) // deprecation: Resteasy.getContextData has no simple alternative; unused: method invoked by JAX-RS at runtime
+    public void filterApplications(ContainerRequestContext request,
+                                   ContainerResponseContext response) {
+        String path = request.getUriInfo().getPath();
+        if (!path.endsWith("/account/applications")) {
+            return;
+        }
+
+        LOG.tracef("Intercepted request to '%s', applying account applications filter", path);
+
+        KeycloakSession session = Resteasy.getContextData(KeycloakSession.class);
+        if (session == null) {
+            LOG.warn("Could not obtain KeycloakSession from context, skipping filtering");
+            return;
+        }
+
+        AccountApplicationsFilterProvider filterProvider = getFilterProvider(session);
+        if (filterProvider == null) {
+            LOG.debug("No AccountApplicationsFilterProvider found, skipping filtering");
+            return;
+        }
+
+        AccountApplicationsFilterConfig config = filterProvider.getConfig();
+        if (!config.isFilteringEnabled()) {
+            LOG.debugf("Account applications filtering is disabled (filterDynamicApps=%s, filterAlwaysDisplayApps=%s)",
+                config.shouldFilterDynamicApps(), config.shouldFilterAlwaysDisplayApps());
+            return;
+        }
+
+        LOG.tracef("Filter config: filterDynamicApps=%s, filterAlwaysDisplayApps=%s",
+            config.shouldFilterDynamicApps(), config.shouldFilterAlwaysDisplayApps());
+
+        AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
+            .setRealm(session.getContext().getRealm())
+            .setConnection(session.getContext().getConnection())
+            .setHeaders(session.getContext().getRequestHeaders())
+            .authenticate();
+
+        if (authResult == null) {
+            LOG.debug("No authenticated user found, skipping filtering");
+            return;
+        }
+
+        UserModel user = authResult.getUser();
+        RealmModel realm = session.getContext().getRealm();
+        AccessProvider accessProvider = getAccessProvider(session);
+
+        LOG.debugf("Filtering account applications for user '%s' in realm '%s'",
+            user.getUsername(), realm.getName());
+
+        Object entity = response.getEntity();
+        if (entity instanceof Stream) {
+            @SuppressWarnings("unchecked")
+            Stream<ClientRepresentation> clientStream = (Stream<ClientRepresentation>) entity;
+            List<ClientRepresentation> filtered = filterClients(clientStream, realm, user, accessProvider, config);
+            response.setEntity(filtered);
+        } else if (entity instanceof Collection) {
+            @SuppressWarnings("unchecked")
+            Collection<ClientRepresentation> clients = (Collection<ClientRepresentation>) entity;
+            int originalCount = clients.size();
+            List<ClientRepresentation> filtered = filterClients(clients.stream(), realm, user, accessProvider, config);
+            int filteredCount = originalCount - filtered.size();
+            if (filteredCount > 0) {
+                LOG.infof("Filtered %d of %d applications for user '%s' in realm '%s'",
+                    filteredCount, originalCount, user.getUsername(), realm.getName());
+            } else {
+                LOG.debugf("No applications filtered for user '%s' in realm '%s' (showing all %d)",
+                    user.getUsername(), realm.getName(), originalCount);
+            }
+            response.setEntity(filtered);
+        }
+    }
+
+    private List<ClientRepresentation> filterClients(Stream<ClientRepresentation> clients,
+                                                      RealmModel realm,
+                                                      UserModel user,
+                                                      AccessProvider accessProvider,
+                                                      AccountApplicationsFilterConfig config) {
+        return clients
+            .filter(clientRep -> shouldShowApplication(clientRep, realm, user, accessProvider, config))
+            .collect(Collectors.toList());
+    }
+
+    private boolean shouldShowApplication(ClientRepresentation clientRep,
+                                          RealmModel realm,
+                                          UserModel user,
+                                          AccessProvider accessProvider,
+                                          AccountApplicationsFilterConfig config) {
+        ClientModel client = realm.getClientByClientId(clientRep.getClientId());
+        if (client == null) {
+            LOG.debugf("Client '%s' not found in realm, showing in console", clientRep.getClientId());
+            return true;
+        }
+
+        if (!accessProvider.isRestricted(client)) {
+            LOG.tracef("Client '%s' is not restricted, showing in console for user '%s'",
+                clientRep.getClientId(), user.getUsername());
+            return true;
+        }
+
+        boolean isAlwaysDisplay = client.isAlwaysDisplayInConsole();
+        boolean shouldFilter = isAlwaysDisplay
+            ? config.shouldFilterAlwaysDisplayApps()
+            : config.shouldFilterDynamicApps();
+
+        if (!shouldFilter) {
+            String clientType = isAlwaysDisplay ? "always-display" : "dynamic";
+            LOG.tracef("Filtering disabled for %s clients, showing restricted client '%s' for user '%s'",
+                clientType, clientRep.getClientId(), user.getUsername());
+            return true;
+        }
+
+        boolean hasPermission = accessProvider.isPermitted(client, user);
+        if (hasPermission) {
+            LOG.debugf("User '%s' has permission to access restricted client '%s' in realm '%s', showing in console",
+                user.getUsername(), clientRep.getClientId(), realm.getName());
+        } else {
+            String clientType = isAlwaysDisplay ? "always-display" : "dynamic";
+            LOG.warnf("Hiding %s client '%s' from user '%s' in realm '%s' - user lacks required permission",
+                clientType, clientRep.getClientId(), user.getUsername(), realm.getName());
+        }
+        return hasPermission;
+    }
+
+    private AccountApplicationsFilterProvider getFilterProvider(KeycloakSession session) {
+        AccountApplicationsFilterProvider provider = session.getProvider(AccountApplicationsFilterProvider.class);
+        if (provider != null) {
+            return provider;
+        }
+        return session.getProvider(AccountApplicationsFilterProvider.class, AccountApplicationsFilterFactory.PROVIDER_ID);
+    }
+
+    private AccessProvider getAccessProvider(KeycloakSession session) {
+        AccessProvider defaultProvider = session.getProvider(AccessProvider.class);
+        if (defaultProvider != null) {
+            LOG.debugf("Using server-wide default access provider for account applications filter");
+            return defaultProvider;
+        }
+        LOG.infof("No server-wide default access provider configured. Using '%s' as fallback for account applications filter.",
+            ClientRoleBasedAccessProviderFactory.PROVIDER_ID);
+        return session.getProvider(AccessProvider.class, ClientRoleBasedAccessProviderFactory.PROVIDER_ID);
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterConfig.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterConfig.java
@@ -1,0 +1,16 @@
+package de.sventorben.keycloak.authorization.client.account;
+
+public record AccountApplicationsFilterConfig(boolean filterDynamicApps, boolean filterAlwaysDisplayApps) {
+
+    public boolean shouldFilterDynamicApps() {
+        return filterDynamicApps;
+    }
+
+    public boolean shouldFilterAlwaysDisplayApps() {
+        return filterAlwaysDisplayApps;
+    }
+
+    public boolean isFilteringEnabled() {
+        return filterDynamicApps || filterAlwaysDisplayApps;
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterFactory.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterFactory.java
@@ -1,0 +1,91 @@
+package de.sventorben.keycloak.authorization.client.account;
+
+import de.sventorben.keycloak.authorization.client.common.OperationalInfo;
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.provider.ServerInfoAwareProviderFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.keycloak.provider.ProviderConfigProperty.BOOLEAN_TYPE;
+
+public final class AccountApplicationsFilterFactory implements AccountApplicationsFilterProviderFactory, ServerInfoAwareProviderFactory {
+
+    public static final String PROVIDER_ID = "default";
+
+    private static final String FILTER_DYNAMIC_APPS = "filterDynamicApps";
+    private static final boolean FILTER_DYNAMIC_APPS_DEFAULT = true;
+
+    private static final String FILTER_ALWAYS_DISPLAY_APPS = "filterAlwaysDisplayApps";
+    private static final boolean FILTER_ALWAYS_DISPLAY_APPS_DEFAULT = true;
+
+    private Config.Scope config;
+
+    @Override
+    public AccountApplicationsFilterProvider create(KeycloakSession session) {
+        AccountApplicationsFilterConfig filterConfig = new AccountApplicationsFilterConfig(
+            isFilterDynamicApps(),
+            isFilterAlwaysDisplayApps()
+        );
+        return new DefaultAccountApplicationsFilterProvider(filterConfig);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        this.config = config;
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public Map<String, String> getOperationalInfo() {
+        Map<String, String> operationalInfo = new HashMap<>(OperationalInfo.get());
+        operationalInfo.put(FILTER_DYNAMIC_APPS, String.valueOf(isFilterDynamicApps()));
+        operationalInfo.put(FILTER_ALWAYS_DISPLAY_APPS, String.valueOf(isFilterAlwaysDisplayApps()));
+        return operationalInfo;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+            .property()
+            .name(FILTER_DYNAMIC_APPS)
+            .label("Filter dynamic apps")
+            .defaultValue(FILTER_DYNAMIC_APPS_DEFAULT)
+            .helpText("Filter applications that appear dynamically (via sessions/consents) for restricted clients the user cannot access.")
+            .type(BOOLEAN_TYPE)
+            .add()
+            .property()
+            .name(FILTER_ALWAYS_DISPLAY_APPS)
+            .label("Filter always-display apps")
+            .defaultValue(FILTER_ALWAYS_DISPLAY_APPS_DEFAULT)
+            .helpText("Filter applications marked as 'always display in console' for restricted clients the user cannot access.")
+            .type(BOOLEAN_TYPE)
+            .add()
+            .build();
+    }
+
+    private boolean isFilterDynamicApps() {
+        return config.getBoolean(FILTER_DYNAMIC_APPS, FILTER_DYNAMIC_APPS_DEFAULT);
+    }
+
+    private boolean isFilterAlwaysDisplayApps() {
+        return config.getBoolean(FILTER_ALWAYS_DISPLAY_APPS, FILTER_ALWAYS_DISPLAY_APPS_DEFAULT);
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterProvider.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterProvider.java
@@ -1,0 +1,8 @@
+package de.sventorben.keycloak.authorization.client.account;
+
+import org.keycloak.provider.Provider;
+
+public interface AccountApplicationsFilterProvider extends Provider {
+
+    AccountApplicationsFilterConfig getConfig();
+}

--- a/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterProviderFactory.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterProviderFactory.java
@@ -1,0 +1,6 @@
+package de.sventorben.keycloak.authorization.client.account;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface AccountApplicationsFilterProviderFactory extends ProviderFactory<AccountApplicationsFilterProvider> {
+}

--- a/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterSpi.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/account/AccountApplicationsFilterSpi.java
@@ -1,0 +1,30 @@
+package de.sventorben.keycloak.authorization.client.account;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public final class AccountApplicationsFilterSpi implements Spi {
+
+    private static final String SPI_NAME = "restrict-client-auth-account-filter";
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return SPI_NAME;
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return AccountApplicationsFilterProvider.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<AccountApplicationsFilterProvider>> getProviderFactoryClass() {
+        return AccountApplicationsFilterProviderFactory.class;
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/authorization/client/account/DefaultAccountApplicationsFilterProvider.java
+++ b/src/main/java/de/sventorben/keycloak/authorization/client/account/DefaultAccountApplicationsFilterProvider.java
@@ -1,0 +1,13 @@
+package de.sventorben.keycloak.authorization.client.account;
+
+record DefaultAccountApplicationsFilterProvider(AccountApplicationsFilterConfig config) implements AccountApplicationsFilterProvider {
+
+    @Override
+    public AccountApplicationsFilterConfig getConfig() {
+        return config;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/resources/META-INF/services/de.sventorben.keycloak.authorization.client.account.AccountApplicationsFilterProviderFactory
+++ b/src/main/resources/META-INF/services/de.sventorben.keycloak.authorization.client.account.AccountApplicationsFilterProviderFactory
@@ -1,0 +1,1 @@
+de.sventorben.keycloak.authorization.client.account.AccountApplicationsFilterFactory

--- a/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -1,1 +1,2 @@
 de.sventorben.keycloak.authorization.client.access.RestrictClientAuthSpi
+de.sventorben.keycloak.authorization.client.account.AccountApplicationsFilterSpi

--- a/src/test/java/de/sventorben/keycloak/authorization/client/AccountApplicationsFilterIT.java
+++ b/src/test/java/de/sventorben/keycloak/authorization/client/AccountApplicationsFilterIT.java
@@ -1,0 +1,80 @@
+package de.sventorben.keycloak.authorization.client;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.info.SpiInfoRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static de.sventorben.keycloak.authorization.client.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the AccountApplicationsFilter.
+ * <p>
+ * Note: Full end-to-end testing of the /account/applications endpoint filtering
+ * requires additional realm configuration (audience mappers, scopes) that is
+ * beyond the scope of these basic integration tests. These tests verify the
+ * filter provider is properly loaded and configured.
+ */
+@Testcontainers
+class AccountApplicationsFilterIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccountApplicationsFilterIT.class);
+
+    private static String KEYCLOAK_AUTH_URL;
+
+    @Container
+    private static final KeycloakContainer KEYCLOAK_CONTAINER = FullImageName.createContainer()
+        .withExposedPorts(KEYCLOAK_HTTP_PORT)
+        .withLogConsumer(new Slf4jLogConsumer(LOGGER).withSeparateOutputStreams())
+        .withRealmImportFile("/test-realm-realm.json")
+        .withStartupTimeout(Duration.ofSeconds(90));
+
+    @BeforeAll
+    static void setUp() {
+        KEYCLOAK_AUTH_URL = KEYCLOAK_CONTAINER.getAuthServerUrl();
+        LOGGER.info("Running test with Keycloak image: {}", FullImageName.get());
+    }
+
+    @Test
+    void filterProviderIsLoaded() {
+        try (Keycloak admin = keycloakAdmin()) {
+            // Verify the SPI is registered
+            Map<String, SpiInfoRepresentation> providers = admin.serverInfo().getInfo().getProviders();
+            assertThat(providers).containsKey("restrict-client-auth-account-filter");
+
+            // Verify the default provider is available
+            SpiInfoRepresentation spiInfo = providers.get("restrict-client-auth-account-filter");
+            assertThat(spiInfo.getProviders()).containsKey("default");
+        }
+    }
+
+    @Test
+    void filterConfigurationIsCorrect() {
+        try (Keycloak admin = keycloakAdmin()) {
+            Map<String, SpiInfoRepresentation> providers = admin.serverInfo().getInfo().getProviders();
+            SpiInfoRepresentation spiInfo = providers.get("restrict-client-auth-account-filter");
+            var defaultProvider = spiInfo.getProviders().get("default");
+
+            // Verify operational info contains the expected config
+            Map<String, String> operationalInfo = defaultProvider.getOperationalInfo();
+
+            assertThat(operationalInfo)
+                .containsEntry("filterDynamicApps", "true")
+                .containsEntry("filterAlwaysDisplayApps", "true");
+        }
+    }
+
+    private static Keycloak keycloakAdmin() {
+        return TestConstants.keycloakAdmin(KEYCLOAK_AUTH_URL);
+    }
+}


### PR DESCRIPTION
Feature: Filter Applications on Account Console based on `restricted-access`

I extended the keycloak-restrict-client-auth plugin to filter which applications appear on the Keycloak Account Console's "Applications" page based on the restricted-access state of the client and the user.

I opened a more detailed discussion in the ideas area here: https://github.com/sventorben/keycloak-restrict-client-auth/discussions/473
