### PR TITLE
chore: add SBOM, checksums, and build provenance to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write       # create the GitHub Release / push tag
+      packages: write        # publish to GitHub Packages
+      id-token: write        # build-provenance attestation
+      attestations: write    # build-provenance attestation
+
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -36,10 +42,19 @@ jobs:
         git push origin v${{ github.event.inputs.releaseVersion }}
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Generate checksums
+      run: cd target && sha256sum keycloak-restrict-client-auth.jar > SHA256SUMS
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@v4
+      with:
+        subject-path: target/keycloak-restrict-client-auth.jar
     - name: Release to GitHub releases
       uses: softprops/action-gh-release@v3
       with:
-        files: "target/keycloak-restrict-client-auth.jar"
+        files: |
+          target/keycloak-restrict-client-auth.jar
+          target/SHA256SUMS
+          target/bom.json
         body_path: "RELEASELOG.md"
         fail_on_unmatched_files: true
         tag_name: v${{ github.event.inputs.releaseVersion }}

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,26 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.1.4</version>
             </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputName>bom</outputName>
+                    <!-- Only describe what the JAR actually ships. keycloak-* deps are
+                         'provided' (supplied by the host server), test deps aren't shipped. -->
+                    <includeProvidedScope>false</includeProvidedScope>
+                    <includeTestScope>false</includeTestScope>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Adds supply-chain integrity artifacts to the release pipeline.

- pom.xml: generate a CycloneDX SBOM during the package phase via cyclonedx-maven-plugin. Scoped to shipped contents only — provided (keycloak-*) and test dependencies are excluded, since the jar bundles no third-party code.
- release.yml: emit SHA256SUMS, attest build provenance via actions/attest-build-provenance, and attach SHA256SUMS + bom.json to the GitHub Release. Adds the id-token/attestations permissions the attestation step requires.

Build commands (release:prepare/release:perform) are unchanged.