### PR TITLE
fix(ci): publish and attest the release:perform build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # An explicit permissions block is exhaustive: every scope not listed here is denied, even
+    # those the repository default would otherwise grant.
     permissions:
-      contents: write       # create the GitHub Release / push tag
+      contents: write        # create the GitHub Release / push tag
       packages: write        # publish to GitHub Packages
       id-token: write        # build-provenance attestation
       attestations: write    # build-provenance attestation
+      pull-requests: write   # open the next-development-iteration PR
 
     steps:
     - name: Checkout
@@ -42,19 +45,23 @@ jobs:
         git push origin v${{ github.event.inputs.releaseVersion }}
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    # Publish the artifacts built by release:perform (target/checkout/target), not the
+    # separate release:prepare build in target/. Only the perform build is deployed to
+    # GitHub Packages, so attesting it keeps the Release page, SHA256SUMS and Packages
+    # all describing the same bytes.
     - name: Generate checksums
-      run: cd target && sha256sum keycloak-restrict-client-auth.jar > SHA256SUMS
+      run: cd target/checkout/target && sha256sum keycloak-restrict-client-auth.jar > SHA256SUMS
     - name: Attest build provenance
       uses: actions/attest-build-provenance@v4
       with:
-        subject-path: target/keycloak-restrict-client-auth.jar
+        subject-path: target/checkout/target/keycloak-restrict-client-auth.jar
     - name: Release to GitHub releases
       uses: softprops/action-gh-release@v3
       with:
         files: |
-          target/keycloak-restrict-client-auth.jar
-          target/SHA256SUMS
-          target/bom.json
+          target/checkout/target/keycloak-restrict-client-auth.jar
+          target/checkout/target/SHA256SUMS
+          target/checkout/target/bom.json
         body_path: "RELEASELOG.md"
         fail_on_unmatched_files: true
         tag_name: v${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
## Problem

Two independent defects in the release job, both introduced alongside the supply-chain (SBOM/checksums/attestation) change.

**1. The attested artifact is not the published artifact.**

The job checksums, attests and uploads `target/*`, which is populated by `release:prepare`'s preparation goals (`clean verify`). But the artifact actually deployed to GitHub Packages comes from `release:perform`, which builds in `target/checkout/target` — maven-release-plugin's default `workingDirectory`.

Those are two separate compilations of the same source. Without `project.build.outputTimestamp` they are not byte-identical, so today:

- `SHA256SUMS` on the Release page does not describe the Maven artifact
- the provenance attestation covers a jar nobody consuming via Maven ever receives

**2. The release job cannot open its own PR.**

Before the supply-chain change the job had no `permissions` block and inherited the repository default, which grants `pull-requests: write`. Adding an explicit block to obtain `id-token` and `attestations` made the set exhaustive and silently revoked every scope not listed — including the one the `create-pull-request` step needs. The next release would push `release/<version>` and then fail with `Resource not accessible by integration`, stranding the version bump on a branch with no PR.

## Fix

Point the checksum, attestation and upload steps at `target/checkout/target`, so GitHub Packages, the Release page assets, `SHA256SUMS` and the attestation all describe the same bytes. Add `pull-requests: write`, with a note above the block recording that it is exhaustive so the next scope added does not repeat this.

Build commands (`release:prepare` / `release:perform`) are unchanged.

## Notes

`target/checkout` survives `release:perform`'s cleanup, so the upload steps resolve. This is workflow-only — it cannot be exercised outside a real release, so the paths were verified by reading maven-release-plugin's `workingDirectory` semantics against this repo's `-DlocalCheckout=true` invocation rather than by a test run.