### PR TITLE
chore(deps): Update Keycloak dependencies to 26.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,7 +38,7 @@ body:
     label: Version
     description: |
       examples:
-        - **Keycloak**: 26.6.1
+        - **Keycloak**: 26.7.0
         - **This extension**: 26.1.0
     value: |
         - Keycloak:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keycloak_version: [ 26.2.5, 26.3.5, 26.4.7, 26.5.7, 26.6.1, latest ]
+        keycloak_version: [ 26.2.5, 26.3.5, 26.4.7, 26.5.7, 26.6.4, 26.7.0, latest ]
         keycloak_dist: [quarkus]
         experimental: [false]
         include:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keycloak_version: [ 21.0.2, 21.1.2, 22.0.5, 23.0.7, 24.0.5, 25.0.6, 26.0.8, 26.1.5, 26.2.5, 26.3.5, 26.4.7, 26.5.7, 26.6.1, latest, nightly ]
+        keycloak_version: [ 21.0.2, 21.1.2, 22.0.5, 23.0.7, 24.0.5, 25.0.6, 26.0.8, 26.1.5, 26.2.5, 26.3.5, 26.4.7, 26.5.7, 26.6.4, 26.7.0, latest, nightly ]
         extension_version: [ 20.0.1, 21.0.0, 22.0.0, 23.0.0, 24.0.0, 25.0.0, 26.0.0, 26.1.0 ]
     name: Compatibility (KC ${{ matrix.keycloak_version }}, Extension ${{ matrix.extension_version }})
     steps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a simple Keycloak authenticator to restrict user authorization on clients.
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/sventorben/keycloak-restrict-client-auth?sort=semver)
-![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-26.6.1-blue)
+![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-26.7.0-blue)
 ![GitHub Release Date](https://img.shields.io/github/release-date-pre/sventorben/keycloak-restrict-client-auth)
 ![Github Last Commit](https://img.shields.io/github/last-commit/sventorben/keycloak-restrict-client-auth)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   keycloak:
     container_name: keycloak
-    image: quay.io/keycloak/keycloak:26.6.1
+    image: quay.io/keycloak/keycloak:26.7.0
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <!-- For compilation -->
-        <version.keycloak>26.6.3</version.keycloak>
+        <version.keycloak>26.7.0</version.keycloak>
 
         <!-- For compatibility tests -->
         <keycloak.version>${version.keycloak}</keycloak.version>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
-            <version>26.0.9</version>
+            <version>26.0.11</version>
             <scope>test</scope>
         </dependency>
         <!-- Logging -->


### PR DESCRIPTION
## Changes

Bump the compile-time Keycloak dependency from 26.6.3 to 26.7.0 (current stable, released 2026-07-09) and add 26.7.0 to both compatibility matrices.

Also folds in #505 — the test-scoped `org.keycloak:keycloak-admin-client` bump — since it tracks the same Keycloak release train. That goes to **26.0.11** rather than the 26.0.10 Dependabot originally proposed, as 26.0.11 is now the latest published release on Maven Central. Among the changes since 26.0.9 is a path injection fix in the access denied page check.

## Drifted version references

The user-facing version references had fallen out of sync with the pom — the README badge, `docker-compose.yml` and the bug report template all still named **26.6.1** while the build compiled against **26.6.3**. All three now point at 26.7.0 so they agree again.

Also corrects `26.6.1` to `26.6.4` in both matrices, which is the current patch of that line.

## Verification

`mvn clean test` against 26.7.0 + admin-client 26.0.11 in a clean checkout: compiles without errors, **75 tests pass**. Integration tests were not run locally (they need Docker); CI covers those.